### PR TITLE
feat: フォーム入力のシャッフル機能を追加

### DIFF
--- a/src/app/api/shuffle/route.ts
+++ b/src/app/api/shuffle/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+
+export async function POST(request: Request) {
+    const { members } = await request.json() as { members: string[] };
+    const result = members.sort(() => Math.random() - 0.5);
+    return NextResponse.json({ members: result });
+}

--- a/src/app/form/form.tsx
+++ b/src/app/form/form.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { useState, useCallback, useRef } from "react"
+
+export function ShuffleMemberForm() {
+    // 結果
+    const [result, setResult] = useState([] as string[]);
+    // 要素への参照
+    const firstRef = useRef<HTMLInputElement>(null);
+    const secondRef = useRef<HTMLInputElement>(null);
+    const thirdRef = useRef<HTMLInputElement>(null);
+    // 通信
+    const callApi = useCallback(async () => {
+        const members = [] as string[];
+        const refs = [firstRef, secondRef, thirdRef];
+        for (const ref of refs) {
+            if (ref.current?.value) {
+                members.push(ref.current?.value);
+            }
+        }
+        const res = await fetch('/api/shuffle', {
+            method: 'POST',
+            body: JSON.stringify({ members })
+        });
+        if (res.ok) {
+            const result = await res.json() as { members: string[] };
+            setResult(result.members);
+        }
+    }, [])
+    return (
+        <>
+            <label htmlFor="first">1人目</label>
+            <input type="text" ref={firstRef} id="first" name="first" placeholder="1人目の名前を入力"/><br/>
+            <label htmlFor="second">2人目</label>
+            <input type="text" ref={secondRef} id="second" name="second" placeholder="2人目の名前を入力"/><br/>
+            <label htmlFor="third">3人目</label>
+            <input type="text" ref={thirdRef} id="third" name="third" placeholder="3人目の名前を入力"/><br/>
+            <button onClick={callApi}>シャッフル</button><br/>
+            <label htmlFor="result">結果</label><br/>
+            <output id="result" htmlFor="first second third fourth">{result.join("→")}</output>
+        </>
+    )
+}

--- a/src/app/form/page.tsx
+++ b/src/app/form/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import { ShuffleMemberForm } from "./form";
+
+export const metadata: Metadata = {
+    title: "入力フォーム",
+    description: "Playwrightハンズオンの第2のステップ",
+};
+
+export default function Form() {
+    return (
+        <main>
+            <h1>入力フォーム</h1>
+            <ShuffleMemberForm/>
+        </main>
+    )
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,8 +15,14 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body className={inter.className}>{children}</body>
+    <html lang="ja">
+      <body className={inter.className}>
+        <ul>
+          <li><a href="/">ホーム</a></li>
+          <li><a href="/form">入力フォーム</a></li>
+        </ul>
+        {children}
+      </body>
     </html>
   );
 }

--- a/tests/form.spec.ts
+++ b/tests/form.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test('フォーム画面への遷移', async ({ page }) => {
+    await page.goto('http://localhost:3000/');
+    await page.getByRole('link', { name: '入力フォーム' }).click();
+    await expect(page).toHaveURL('http://localhost:3000/form');
+    await expect(page.getByRole('heading', { name: '入力フォーム' })).toBeVisible();
+});
+
+test('フォーム操作のテスト', async ({ page }) => {
+    await page.goto('http://localhost:3000/form');
+    await page.getByRole('textbox', {name: /1人目/}).fill('項羽');
+    await page.getByRole('textbox', {name: /2人目/}).fill('劉邦');
+    await page.getByRole('button', {name: /シャッフル/}).click();
+    await expect(page.getByRole('status', {name: /結果/})).toHaveText(/(項羽→劉邦)|(劉邦→項羽)/);
+});


### PR DESCRIPTION
- 新しいAPIエンドポイント(route.ts)を作成し、POSTリクエストで受け取ったメンバー名をシャッフルする機能を実装
- フォーム入力コンポーネント(form.tsx)を追加し、シャッフルするための入力フィールドとボタンを提供
- フォームページ(page.tsx)を追加し、入力フォームを表示
- レイアウト(layout.tsx)にナビゲーションリンクを追加し、フォームページへのアクセスを可能に
- Playwrightによるテスト(form.spec.ts)を追加し、フォームの表示および動作を検証

branch: feature/shuffle-form